### PR TITLE
Use Qksms existing send functionality

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
@@ -294,13 +294,13 @@ class MessageRepositoryImpl @Inject constructor(
     }
 
     override fun sendMessage(
+        saveSentMessage: Boolean,
         subId: Int,
         threadId: Long,
         addresses: List<String>,
         body: String,
         attachments: List<Attachment>,
-        delay: Int,
-        saveSentMessage: Boolean
+        delay: Int
     ) {
         val saveMessage = delay > 0 || saveSentMessage
         val signedBody = when {

--- a/domain/src/main/java/com/moez/QKSMS/interactor/SendMessage.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/SendMessage.kt
@@ -40,7 +40,8 @@ class SendMessage @Inject constructor(
         val addresses: List<String>,
         val body: String,
         val attachments: List<Attachment> = listOf(),
-        val delay: Int = 0
+        val delay: Int = 0,
+        val saveSentMessage: Boolean = true
     )
 
     override fun buildObservable(params: Params): Flowable<*> = Flowable.just(Unit)
@@ -52,7 +53,7 @@ class SendMessage @Inject constructor(
                     else -> params.threadId
                 }
                 messageRepo.sendMessage(params.subId, threadId, params.addresses, params.body, params.attachments,
-                        params.delay)
+                        params.delay, params.saveSentMessage)
             }
             .mapNotNull {
                 // If the threadId wasn't provided, then it's probably because it doesn't exist in Realm.

--- a/domain/src/main/java/com/moez/QKSMS/interactor/SendMessage.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/SendMessage.kt
@@ -52,8 +52,8 @@ class SendMessage @Inject constructor(
                     0L -> TelephonyCompat.getOrCreateThreadId(context, params.addresses.toSet())
                     else -> params.threadId
                 }
-                messageRepo.sendMessage(params.subId, threadId, params.addresses, params.body, params.attachments,
-                        params.delay, params.saveSentMessage)
+                messageRepo.sendMessage(params.saveSentMessage, params.subId, threadId, params.addresses, params.body, params.attachments,
+                        params.delay)
             }
             .mapNotNull {
                 // If the threadId wasn't provided, then it's probably because it doesn't exist in Realm.

--- a/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
+++ b/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
@@ -62,17 +62,14 @@ interface MessageRepository {
 
     fun markUnread(vararg threadIds: Long)
 
-    /**
-     * @param saveSentMessage True by default. Will always be taken as true if delay is greater than 0
-     */
     fun sendMessage(
+        saveSentMessage: Boolean,
         subId: Int,
         threadId: Long,
         addresses: List<String>,
         body: String,
         attachments: List<Attachment>,
-        delay: Int = 0,
-        saveSentMessage: Boolean = true
+        delay: Int = 0
     )
 
     /**

--- a/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
+++ b/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
@@ -62,13 +62,17 @@ interface MessageRepository {
 
     fun markUnread(vararg threadIds: Long)
 
+    /**
+     * @param saveSentMessage True by default. Will always be taken as true if delay is greater than 0
+     */
     fun sendMessage(
         subId: Int,
         threadId: Long,
         addresses: List<String>,
         body: String,
         attachments: List<Attachment>,
-        delay: Int = 0
+        delay: Int = 0,
+        saveSentMessage: Boolean = true
     )
 
     /**
@@ -83,7 +87,7 @@ interface MessageRepository {
      */
     fun cancelDelayedSms(id: Long)
 
-    fun insertSentSms(subId: Int, threadId: Long, address: String, body: String, date: Long): Message
+    fun insertSentSms(subId: Int, threadId: Long, address: String, body: String, date: Long, saveMessage: Boolean): Message
 
     fun insertReceivedSms(subId: Int, address: String, body: String, sentTime: Long): Message
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/gateway/GatewayServer.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/gateway/GatewayServer.kt
@@ -56,8 +56,8 @@ class GatewayServer(
         reader.beginObject()
         while (reader.hasNext()) {
             when (reader.nextName()) {
-                "to"      -> phone = reader.nextString()
-                "message" -> message = reader.nextString()
+                "to"          -> phone = reader.nextString()
+                "message"     -> message = reader.nextString()
                 "saveMessage" -> saveMessage = reader.nextBoolean()
             }
         }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/gateway/GatewayServer.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/gateway/GatewayServer.kt
@@ -15,7 +15,7 @@ class GatewayServer(
 ) : Server(port) {
 
     interface Handler {
-        fun onSendMessage(phone: String, message: String): String?
+        fun onSendMessage(phone: String, message: String, saveMessage: Boolean): String?
     }
 
     init {
@@ -50,6 +50,7 @@ class GatewayServer(
 
         var phone: String? = null
         var message: String? = null
+        var saveMessage = false
 
         val reader = JsonReader(request.reader)
         reader.beginObject()
@@ -57,11 +58,12 @@ class GatewayServer(
             when (reader.nextName()) {
                 "to"      -> phone = reader.nextString()
                 "message" -> message = reader.nextString()
+                "saveMessage" -> saveMessage = reader.nextBoolean()
             }
         }
 
         val result = if (phone != null && message != null) {
-            handler.onSendMessage(phone, message)
+            handler.onSendMessage(phone, message, saveMessage)
         } else {
             "Missing phone or message"
         }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/gateway/GatewayService.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/gateway/GatewayService.kt
@@ -12,6 +12,9 @@ import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import com.moez.QKSMS.R
 import com.moez.QKSMS.common.util.NotificationManagerImpl
+import com.moez.QKSMS.injection.appComponent
+import com.moez.QKSMS.interactor.SendMessage
+import javax.inject.Inject
 
 class GatewayService : Service(), GatewayServer.Handler {
 
@@ -21,6 +24,7 @@ class GatewayService : Service(), GatewayServer.Handler {
     }
 
     private lateinit var gatewayServer: GatewayServer
+    @Inject lateinit var sendMessage: SendMessage
 
     private fun createNotification(context: Context): Notification {
         val intent = Intent(this, GatewayActivity::class.java)
@@ -36,6 +40,7 @@ class GatewayService : Service(), GatewayServer.Handler {
 
     @Suppress("DEPRECATION")
     override fun onCreate() {
+        appComponent.inject(this)
         val key = PreferenceManager
             .getDefaultSharedPreferences(this)
             .getString(GatewayViewModel.PREFERENCE_KEY, null)
@@ -58,7 +63,7 @@ class GatewayService : Service(), GatewayServer.Handler {
 
     override fun onSendMessage(phone: String, message: String): String? {
         return try {
-            SmsManager.getDefault().sendTextMessage(phone, null, message, null, null)
+            sendMessage.execute(SendMessage.Params(-1, 0L, listOf(phone), message))
             null
         } catch (e: Exception) {
             Toast.makeText(this, e.message, Toast.LENGTH_LONG).show()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/gateway/GatewayService.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/gateway/GatewayService.kt
@@ -61,9 +61,9 @@ class GatewayService : Service(), GatewayServer.Handler {
         return null
     }
 
-    override fun onSendMessage(phone: String, message: String): String? {
+    override fun onSendMessage(phone: String, message: String, saveMessage: Boolean): String? {
         return try {
-            sendMessage.execute(SendMessage.Params(-1, 0L, listOf(phone), message))
+            sendMessage.execute(SendMessage.Params(-1, 0L, listOf(phone), message, saveSentMessage = saveMessage))
             null
         } catch (e: Exception) {
             Toast.makeText(this, e.message, Toast.LENGTH_LONG).show()

--- a/presentation/src/main/java/com/moez/QKSMS/injection/AppComponent.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/injection/AppComponent.kt
@@ -35,6 +35,7 @@ import com.moez.QKSMS.feature.blocking.messages.BlockedMessagesController
 import com.moez.QKSMS.feature.blocking.numbers.BlockedNumbersController
 import com.moez.QKSMS.feature.compose.editing.DetailedChipView
 import com.moez.QKSMS.feature.conversationinfo.injection.ConversationInfoComponent
+import com.moez.QKSMS.feature.gateway.GatewayService
 import com.moez.QKSMS.feature.settings.SettingsController
 import com.moez.QKSMS.feature.settings.about.AboutController
 import com.moez.QKSMS.feature.settings.swipe.SwipeActionsController
@@ -73,6 +74,7 @@ interface AppComponent {
     fun inject(dialog: QkDialog)
 
     fun inject(service: WidgetAdapter)
+    fun inject(service: GatewayService)
 
     /**
      * This can't use AndroidInjection, or else it will crash on pre-marshmallow devices


### PR DESCRIPTION
Fixes #7 
Fixes #9 

This changes Traccar sms sending so that it uses Qksms functionality. That way sent message is saved and message is split if needed

This would also make #5 and #8 irrelevant. I believe this is a better approach

@tananaev